### PR TITLE
Add CLI options for word cloud size

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ To customize the stopwords that should be excluded from analysis:
 
 ### Command-Line Arguments
 
-Both scripts support optional command-line arguments for customization:
+Both scripts support optional command-line arguments for customization. In
+`wordcloudsr.py` you can also adjust the image dimensions and the maximum
+number of words in the cloud:
 
 ```bash
 # Custom input/output directories
@@ -158,6 +160,12 @@ python wordcloudsr.py --input custom_input --output custom_output
 
 # Disable collocations
 python wordcloudsr.py --no-collocations
+
+# Custom word cloud size
+python wordcloudsr.py --width 1600 --height 900
+
+# Limit number of words
+python wordcloudsr.py --max-words 100
 
 # Specify different stopwords file
 python wordfrqsr.py --stopwords custom_stopwords.txt

--- a/utils.py
+++ b/utils.py
@@ -119,6 +119,9 @@ def parse_arguments() -> Dict[str, Any]:
     parser.add_argument('--stopwords', default='stopwords.txt',
                         help='Stopwords file path (default: stopwords.txt)')
 
+    parser.add_argument('--no-collocations', action='store_true',
+                        help='Disable generation of collocations word clouds')
+
     parser.add_argument('--width', type=int, default=1200,
                         help='Width of the generated word clouds (default: 1200)')
     parser.add_argument('--height', type=int, default=800,

--- a/utils.py
+++ b/utils.py
@@ -118,7 +118,14 @@ def parse_arguments() -> Dict[str, Any]:
     
     parser.add_argument('--stopwords', default='stopwords.txt',
                         help='Stopwords file path (default: stopwords.txt)')
-    
+
+    parser.add_argument('--width', type=int, default=1200,
+                        help='Width of the generated word clouds (default: 1200)')
+    parser.add_argument('--height', type=int, default=800,
+                        help='Height of the generated word clouds (default: 800)')
+    parser.add_argument('--max-words', type=int, default=200,
+                        help='Maximum number of words in the word cloud (default: 200)')
+
     parser.add_argument('--debug', action='store_true',
                         help='Enable debug logging')
     

--- a/wordcloudsr.py
+++ b/wordcloudsr.py
@@ -261,19 +261,10 @@ def main():
     """Parse arguments and run the word cloud generation process."""
     # Get command line arguments
     args = parse_arguments()
-    
-    # Add wordcloud-specific arguments
-    parser = argparse.ArgumentParser(description='WordCloudSR - Serbian Word Cloud Generator')
-    parser.add_argument('--no-collocations', action='store_true',
-                      help='Disable generation of collocations word clouds')
-    parser.add_argument('--width', type=int, default=1200)
-    parser.add_argument('--height', type=int, default=800)
-    parser.add_argument('--max-words', type=int, default=200)
-    wordcloud_args = parser.parse_args()
-    
+
     # Run the main process
     process_files(
-        collocations=not wordcloud_args.no_collocations,
+        collocations=not args['no_collocations'],
         input_dir=args['input'],
         output_dir=args['output'],
         stopwords_file=args['stopwords'],


### PR DESCRIPTION
## Summary
- allow --width, --height and --max-words in `parse_arguments`
- pass the values through `process_files` and `process_directory`
- document new options and update examples

## Testing
- `python test.py` *(fails: ModuleNotFoundError: No module named 'treetaggerwrapper')*
- `python -m py_compile utils.py wordcloudsr.py wordfrqsr.py SerbianTagger.py pd.py`

------
https://chatgpt.com/codex/tasks/task_e_6847149a9dd48329a874bdb869d8b268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to customize word cloud image width, height, and maximum number of words via command-line arguments.

- **Documentation**
  - Updated usage instructions to describe new command-line options and provide example commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->