### PR TITLE
Rename lemmarizer function

### DIFF
--- a/SerbianTagger.py
+++ b/SerbianTagger.py
@@ -15,6 +15,7 @@ Author: "Petalinkar Saša"
 import os
 import logging
 from typing import Optional
+import warnings
 import treetaggerwrapper as ttpw
 from dotenv import load_dotenv
 
@@ -58,7 +59,7 @@ class SrbTreeTagger:
             logger.error(f"Failed to initialize TreeTagger: {e}")
             raise ValueError(f"TreeTagger initialization failed: {e}")
 
-    def lemmarizer(self, text: str) -> Optional[str]:
+    def lemmatize(self, text: str) -> Optional[str]:
         """
         Replace all words in a string with their lemmas using TreeTagger.
 
@@ -70,7 +71,7 @@ class SrbTreeTagger:
             
         Examples:
             >>> tagger = SrbTreeTagger()
-            >>> tagger.lemmarizer("Ovo je kratka rečenica za testiranje.")
+            >>> tagger.lemmatize("Ovo je kratka rečenica za testiranje.")
             "ovaj jesam kratak rečenica za testiranje ."
         """
         if text is None:
@@ -96,3 +97,16 @@ class SrbTreeTagger:
         except Exception as e:
             logger.error(f"Unexpected error during lemmatization: {e}")
             return text  # Return original text on error
+
+    def lemmarizer(self, text: str) -> Optional[str]:
+        """Deprecated wrapper for :meth:`lemmatize`.
+
+        This method is maintained for backward compatibility and will be removed
+        in a future release. Use :func:`lemmatize` instead.
+        """
+        warnings.warn(
+            "lemmarizer is deprecated, use lemmatize instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.lemmatize(text)

--- a/test.py
+++ b/test.py
@@ -32,7 +32,7 @@ def test_lemmatization():
         print("Input sentence:")
         print(f"  \"{sentence}\"")
         
-        lemmatized = tagger.lemmarizer(sentence)
+        lemmatized = tagger.lemmatize(sentence)
         
         print("\nLemmatized output:")
         print(f"  \"{lemmatized}\"")

--- a/wordcloudsr.py
+++ b/wordcloudsr.py
@@ -129,7 +129,7 @@ def process_directory(directory: str, tagger: SrbTreeTagger, stopwords: Set[str]
         return None, None
         
     # Lemmatize the combined text
-    lemmatized_text = tagger.lemmarizer(all_text)
+    lemmatized_text = tagger.lemmatize(all_text)
     
     if not lemmatized_text:
         logger.warning(f"Lemmatization failed for {directory}, skipping")

--- a/wordfrqsr.py
+++ b/wordfrqsr.py
@@ -48,7 +48,7 @@ def calculate_lemma_frequencies(text: str, tagger: SrbTreeTagger, stopwords: Set
         return []
         
     # Lemmatize the text
-    lemmatized_text = tagger.lemmarizer(text)
+    lemmatized_text = tagger.lemmatize(text)
     
     if not lemmatized_text:
         logger.warning("Lemmatization produced empty result")


### PR DESCRIPTION
## Summary
- rename `lemmarizer` method to `lemmatize`
- update scripts to call the new method
- keep a `lemmarizer` wrapper for backward compatibility

## Testing
- `python -m py_compile SerbianTagger.py wordcloudsr.py wordfrqsr.py test.py`

------
https://chatgpt.com/codex/tasks/task_e_68471499af3883299d1ca5d1d16d5352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected method calls from the outdated name to the updated lemmatization function across the application, ensuring consistent and accurate lemmatization.

- **Refactor**
  - Updated the lemmatization method name for improved clarity.
  - Introduced a deprecated wrapper for backward compatibility, which issues a warning to encourage using the new method name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->