### PR TITLE
Add no-collocations flag to utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,8 @@ To customize the stopwords that should be excluded from analysis:
 Both scripts support optional command-line arguments for customization:
 
 ```bash
-# Custom input/output directories
-python wordcloudsr.py --input custom_input --output custom_output
-
-# Disable collocations
-python wordcloudsr.py --no-collocations
+# Custom input/output directories and disable collocations
+python wordcloudsr.py --input custom_input --output custom_output --no-collocations
 
 # Specify different stopwords file
 python wordfrqsr.py --stopwords custom_stopwords.txt

--- a/utils.py
+++ b/utils.py
@@ -121,6 +121,9 @@ def parse_arguments() -> Dict[str, Any]:
     
     parser.add_argument('--debug', action='store_true',
                         help='Enable debug logging')
+
+    parser.add_argument('--no-collocations', action='store_true',
+                        help='Disable generation of collocations word clouds')
     
     args = parser.parse_args()
     

--- a/wordcloudsr.py
+++ b/wordcloudsr.py
@@ -227,16 +227,10 @@ def main():
     """Parse arguments and run the word cloud generation process."""
     # Get command line arguments
     args = parse_arguments()
-    
-    # Add wordcloud-specific arguments
-    parser = argparse.ArgumentParser(description='WordCloudSR - Serbian Word Cloud Generator')
-    parser.add_argument('--no-collocations', action='store_true',
-                      help='Disable generation of collocations word clouds')
-    wordcloud_args = parser.parse_args()
-    
+
     # Run the main process
     process_files(
-        collocations=not wordcloud_args.no_collocations,
+        collocations=not args['no_collocations'],
         input_dir=args['input'],
         output_dir=args['output'],
         stopwords_file=args['stopwords']


### PR DESCRIPTION
## Summary
- expose `--no-collocations` through `utils.parse_arguments`
- use single parser in `wordcloudsr.main`
- update README command examples

## Testing
- `pip install -r requirements.txt`
- `python test.py` *(fails: SafeConfigParser missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847149900408329b00db3b15c1457a6