### PR TITLE
Fix duplicate CLI argument

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -131,9 +131,6 @@ def parse_arguments() -> Dict[str, Any]:
 
     parser.add_argument('--debug', action='store_true',
                         help='Enable debug logging')
-
-    parser.add_argument('--no-collocations', action='store_true',
-                        help='Disable generation of collocations word clouds')
     
     args = parser.parse_args()
     


### PR DESCRIPTION
## Summary
- remove redundant `--no-collocations` option

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bf9f8947083299529cd13adf08f1f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with duplicate command-line arguments for disabling collocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->